### PR TITLE
Addition of a parser service to fetch definition values/features

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,8 @@
         <maven.version>3.3.9</maven.version>
         <junit.version>4.12</junit.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <hamcrest-all.version>1.3</hamcrest-all.version>
+        <swagger-parser.version>1.0.41</swagger-parser.version>
     </properties>
 
     <dependencies>
@@ -100,13 +102,26 @@
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-parser</artifactId>
-            <version>1.0.34</version>
-            <scope>test</scope>
+            <version>${swagger-parser.version}</version>
         </dependency>
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock</artifactId>
             <version>2.14.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Needed by junit -->
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <version>${hamcrest-all.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/io/swagger/swaggerhub/plugin/exceptions/DefinitionParsingException.java
+++ b/src/main/java/io/swagger/swaggerhub/plugin/exceptions/DefinitionParsingException.java
@@ -1,0 +1,34 @@
+package io.swagger.swaggerhub.plugin.exceptions;
+
+/**
+ * Thrown to indicate an error has occurred when parsing a given definition. This exception will prevent any further parsing of the definition.
+ */
+public class DefinitionParsingException extends Exception {
+
+    /**
+     * {@inheritDoc}
+     */
+    public DefinitionParsingException() {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public DefinitionParsingException(String message) {
+        super(message);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public DefinitionParsingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public DefinitionParsingException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/io/swagger/swaggerhub/plugin/services/DefinitionParserService.java
+++ b/src/main/java/io/swagger/swaggerhub/plugin/services/DefinitionParserService.java
@@ -1,0 +1,48 @@
+package io.swagger.swaggerhub.plugin.services;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.swagger.swaggerhub.plugin.exceptions.DefinitionParsingException;
+import org.apache.commons.lang3.StringUtils;
+
+
+/**
+ * Service used to fetch definition features
+ */
+public class DefinitionParserService {
+
+    /**
+     * Returns the API identifier by fetching title from the info section of a definition and normalizing.
+     * Any whitespace or non-word characters are replaced by underscores
+     * @param definition
+     * @return
+     */
+    public String getApiId(JsonNode definition) throws DefinitionParsingException {
+
+        String titleValue;
+        try {
+            titleValue = definition.get("info").get("title").asText();
+        }catch (NullPointerException ne){
+            throw new DefinitionParsingException("Unable to fetch a valid API ID", ne);
+        }
+
+        return titleValue.replaceAll("\\W", StringUtils.SPACE).trim().replaceAll("\\s","_");
+
+    }
+
+    /**
+     * Returns the API version from the info section of a definition
+     * @param definition
+     * @return
+     * @throws DefinitionParsingException
+     */
+    public String getVersion(JsonNode definition) throws DefinitionParsingException{
+        String versionValue;
+        try {
+            versionValue = definition.get("info").get("version").asText();
+        }catch (NullPointerException ne){
+            throw new DefinitionParsingException("Unable to fetch the version", ne);
+        }
+
+        return versionValue.trim();
+    }
+}

--- a/src/test/java/io/swagger/swaggerhub/plugin/services/DefinitionParserServiceTest.java
+++ b/src/test/java/io/swagger/swaggerhub/plugin/services/DefinitionParserServiceTest.java
@@ -1,0 +1,136 @@
+package io.swagger.swaggerhub.plugin.services;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.swagger.models.Info;
+import io.swagger.models.Swagger;
+import io.swagger.swaggerhub.plugin.exceptions.DefinitionParsingException;
+import io.swagger.util.Yaml;
+import org.junit.Before;
+import org.junit.Test;
+
+
+import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+
+public class DefinitionParserServiceTest {
+
+    private static DefinitionParserService definitionParserService;
+    private Swagger swagger;
+    private ObjectMapper objectMapper;
+
+    @Before
+    public void setupTestClass(){
+        definitionParserService = new DefinitionParserService();
+
+        this.swagger = new Swagger();
+        Info info = new Info();
+        swagger.setInfo(info);
+
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    public void validDefinition_canParseApiTitleWithSpacesTest() throws Exception {
+        //Given
+        swagger.getInfo().setTitle("Sample API Title");
+        String swaggerString = objectMapper.writeValueAsString(swagger);
+
+        //When
+        String apiId = definitionParserService.getApiId(Yaml.mapper().readTree(swaggerString));
+
+        //Then
+        assertEquals("Sample_API_Title", apiId);
+
+    }
+
+    @Test
+    public void validDefinition_canParseApiTitleWithSpecialCharsTest() throws Exception {
+        //Given
+        swagger.getInfo().setTitle("Sample!API%Title**");
+        String swaggerString = objectMapper.writeValueAsString(swagger);
+
+        //When
+        String apiId = definitionParserService.getApiId(Yaml.mapper().readTree(swaggerString));
+
+        //Then
+        assertEquals("Sample_API_Title", apiId);
+
+    }
+
+    @Test(expected = DefinitionParsingException.class)
+    public void definition_missingTitle_throwsExceptionWhenParsingForApiIdTest() throws Exception {
+        //Given
+        String swaggerString = objectMapper.writeValueAsString(swagger);
+        JsonNode swaggerNode = Yaml.mapper().readTree(swaggerString);
+        swaggerNode = removeElementFromNode(swaggerNode.get("info"), "title");
+
+        //When
+        definitionParserService.getApiId(swaggerNode);
+
+        //Then
+        fail();
+    }
+
+    @Test(expected = DefinitionParsingException.class)
+    public void definition_missingInfoSection_throwsExceptionWhenParsingForApiIdTest() throws Exception {
+        //Given
+        String swaggerString = objectMapper.writeValueAsString(swagger);
+        JsonNode swaggerNode = Yaml.mapper().readTree(swaggerString);
+        swaggerNode = removeElementFromNode(swaggerNode, "info");
+
+        //When
+        definitionParserService.getApiId(swaggerNode);
+
+        //Then
+        fail();
+    }
+
+    @Test
+    public void validDefinition_canParseVersionTest() throws Exception {
+        //Given
+        String apiVersion = "1.0.0";
+        swagger.getInfo().setVersion(apiVersion);
+        String swaggerString = objectMapper.writeValueAsString(swagger);
+
+        //When
+        String parsedApiVersion = definitionParserService.getVersion(Yaml.mapper().readTree(swaggerString));
+
+        //Then
+        assertEquals(apiVersion, parsedApiVersion);
+
+    }
+
+    @Test(expected = DefinitionParsingException.class)
+    public void definition_missingVersion_throwsExceptionWhenParsingForVersionTest() throws Exception {
+        //Given
+        String swaggerString = objectMapper.writeValueAsString(swagger);
+        JsonNode swaggerNode = Yaml.mapper().readTree(swaggerString);
+        swaggerNode = removeElementFromNode(swaggerNode.get("info"), "version");
+
+        //When
+        definitionParserService.getVersion(swaggerNode);
+
+        //Then
+        fail();
+    }
+
+    @Test(expected = DefinitionParsingException.class)
+    public void definition_missingInfoSection_throwsExceptionWhenParsingForVersionTest() throws Exception {
+        //Given
+        String swaggerString = objectMapper.writeValueAsString(swagger);
+        JsonNode swaggerNode = Yaml.mapper().readTree(swaggerString);
+        swaggerNode = removeElementFromNode(swaggerNode, "info");
+
+        //When
+        definitionParserService.getVersion(swaggerNode);
+
+        //Then
+        fail();
+    }
+
+    private JsonNode removeElementFromNode(JsonNode node, String fieldName){
+        return ((ObjectNode) node).remove(fieldName);
+    }
+}


### PR DESCRIPTION
Work is being done in anticipation of uploading multiple definitions via a directory/regex combination

Currently both values are explicitly set within the plugin configuration. We intend to add the ability to upload multiple definitions at a time via a named directory with the option of a given regex pattern to filter which files to upload. The parser service here would fetch the API version and ID from the definition; avoiding the need to explicitly set those values for each definition.

**Notes:**
* Accompanying tests added
* Current functionality unaffected and will remain so in future.

@jsfrench Even though you're no longer with us 😢 I see you were recently developing the plugin, so this may peak your interest.