### PR TITLE
chore: Dependencies update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,14 +48,13 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <swagger-core.version>1.5.9</swagger-core.version>
         <okhttp.version>2.7.5</okhttp.version>
-        <maven.version>3.3.9</maven.version>
-        <junit.version>4.12</junit.version>
+        <maven.version>3.8.1</maven.version>
+        <junit.version>4.13.2</junit.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hamcrest-all.version>1.3</hamcrest-all.version>
-        <swagger-parser.version>1.0.41</swagger-parser.version>
-        <surefire.version>3.0.0-M3</surefire.version>
+        <swagger-parser.version>1.0.54</swagger-parser.version>
+        <surefire.version>3.0.0-M5</surefire.version>
     </properties>
 
     <dependencies>
@@ -67,7 +66,7 @@
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.5.1</version>
+            <version>3.6.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -89,7 +88,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.7</version>
+            <version>3.12.0</version>
         </dependency>
         <!-- Required to avoid
              java.lang.ClassNotFoundException: org.apache.maven.execution.MavenExecutionResult
@@ -108,7 +107,7 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock</artifactId>
-            <version>2.14.0</version>
+            <version>2.27.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -147,7 +146,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.7</version>
+                <version>1.6.8</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>
@@ -158,7 +157,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.3</version>
+                <version>3.6.1</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -195,7 +194,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>2.2.1</version>
+                        <version>3.2.1</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>


### PR DESCRIPTION
Updating several depdencies:

- swagger-parser `1.0.41` -> `1.0.54`
- maven-plugin-api, maven-artifact, maven-compat `3.3.9` -> `3.8.1`
- junit `4.12` -> `4.13.2`
- surefire `3.0.0-M3` -> `3.0.0-M5`
- maven-plugin-annotations `3.5.1` -> `3.6.0`
- commons-lang3 `3.7` -> `3.12.0`
- wiremock `2.14.0` -> `2.27.2`
- nexus-staging-maven-plugin `1.6.7` -> `1.6.8`
- maven-plugin-plugin `3.3` -> `3.6.1`
- maven-source-plugin `2.2.1` -> `3.2.1`

Removed `swagger-core.version` property as it isn't being used.