### PR TITLE
Update dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>io.swagger</groupId>
     <artifactId>swaggerhub-maven-plugin</artifactId>
-    <version>1.0.10</version>
+    <version>1.0.11</version>
     <packaging>maven-plugin</packaging>
     <name>SwaggerHub Maven Plugin</name>
     <description>A maven plugin for downloading and uploading Swagger/OAS definitions from/to SwaggerHub as
@@ -30,30 +30,17 @@
         </license>
     </licenses>
 
-    <developers>
-        <developer>
-            <id>jsfrench</id>
-            <name>John French</name>
-            <email>frenchE@gmail.com</email>
-        </developer>
-        <developer>
-            <id>webron</id>
-            <name>Ron Ratovsky</name>
-            <email>webron@gmail.com</email>
-        </developer>
-    </developers>
-
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <okhttp.version>4.10.0</okhttp.version>
-        <maven.version>3.8.1</maven.version>
+        <okhttp.version>4.11.0</okhttp.version>
+        <maven.version>3.9.5</maven.version>
         <junit.version>4.13.2</junit.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hamcrest-all.version>1.3</hamcrest-all.version>
-        <swagger-parser.version>1.0.65</swagger-parser.version>
+        <swagger-parser.version>1.0.67</swagger-parser.version>
         <surefire.version>3.0.0-M5</surefire.version>
     </properties>
 
@@ -107,7 +94,7 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-jre8-standalone</artifactId>
-            <version>2.35.0</version>
+            <version>2.35.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -158,7 +145,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.6.1</version>
+                <version>3.9.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
The existing wiremock version has security vulnerability: [CVE-2023-41327](https://github.com/advisories/GHSA-hq8w-9w8w-pmx7)
The dependency is only included as a test dependency so a release of the `swaggerhub-maven-plugin` is not required.

Other dependency updates: 
- maven-plugin-plugin
- maven-plugin-api
- maven-artifact
- okhttp4
- swagger-parser

Additionally removed developer information for devs who are no longer active in the project.